### PR TITLE
Fix NPE when opening links from quoted statuses

### DIFF
--- a/husky/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/husky/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -919,7 +919,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (quote != null && this.quoteView != null) {
             CharSequence emojifiedText =
                 CustomEmojiHelper.emojify(quote, statusEmojis, this.quoteText);
-            LinkHelper.setClickableText(this.quoteText, emojifiedText, null, null);
+            LinkHelper.setClickableText(this.quoteText, emojifiedText, null, listener);
 
             CharSequence emojifiedName =
                 CustomEmojiHelper.emojify(quoteFullName, accountEmojis, this.quoteName, true);


### PR DESCRIPTION
Fixes NPE on `CustomURLSpan.listener` in `LinkHelper.setClickableText` when opening a link from quoted statuses.

Relevant stack trace:

```
09-16 19:29:29.129  5867  5867 E MessageQueue-JNI: Exception in MessageQueue callback: handleReceiveCallback
09-16 19:29:29.136  5867  5867 E MessageQueue-JNI: java.lang.NullPointerException: Attempt to invoke interface method 'void com.keylesspalace.tusky.interfaces.LinkListener.onViewUrl(java.lang.String)' on a null object reference
09-16 19:29:29.136  5867  5867 E MessageQueue-JNI: 	at com.keylesspalace.tusky.util.LinkHelper$3.onClick(LinkHelper.java:122)
09-16 19:29:29.136  5867  5867 E MessageQueue-JNI: 	at android.text.method.LinkMovementMethod.onTouchEvent(LinkMovementMethod.java:244)
09-16 19:29:29.136  5867  5867 E MessageQueue-JNI: 	at android.widget.TextView.onTouchEvent(TextView.java:13159)
09-16 19:29:29.136  5867  5867 E MessageQueue-JNI: 	at android.view.View.performOnTouchCallback(View.java:16447)
09-16 19:29:29.136  5867  5867 E MessageQueue-JNI: 	at android.view.View.dispatchTouchEvent(View.java:16404)
```
