### PR TITLE
Add monochrome icon

### DIFF
--- a/husky/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/husky/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
 	<background android:drawable="@color/tusky_grey_10" />
 	<foreground android:drawable="@drawable/ic_launcher_foreground" />
+	<monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Added monochrome icon for Android 13 "Themed icons" support.
![2024-12-21T11:27:13,031889589+09:00](https://github.com/user-attachments/assets/78359584-a92f-4644-b2d0-c20f25a5f7eb)
